### PR TITLE
chore: add full i18n/localization system (en/ru for widget and iframe)

### DIFF
--- a/src/global-shared/localization/index.ts
+++ b/src/global-shared/localization/index.ts
@@ -1,0 +1,18 @@
+export { widgetTranslations, iframeTranslations } from './translations';
+export type {
+  IframeLocalizationKeys,
+  IframeTranslationKey,
+  Locale,
+  WidgetLocalizationKeys,
+  WidgetTranslationKey,
+} from './types';
+export {
+  getDefaultLocale,
+  getNestedValue,
+  getNestedValueWithFallback,
+  getSafeLocale,
+  getValidLocale,
+  interpolate,
+  isValidLocale,
+} from './utils';
+export { getPluralSuffix, type PluralSuffix } from './pluralization';

--- a/src/global-shared/localization/pluralization.ts
+++ b/src/global-shared/localization/pluralization.ts
@@ -1,0 +1,12 @@
+import type { Locale } from './types';
+
+export type PluralSuffix = 'zero' | 'one' | 'two' | 'few' | 'many' | 'other';
+
+export const getPluralSuffix = (locale: Locale, count: number): PluralSuffix => {
+  try {
+    const pr = new Intl.PluralRules(locale);
+    return pr.select(count) as PluralSuffix;
+  } catch (_e: unknown) {
+    return 'other';
+  }
+};

--- a/src/global-shared/localization/translations/iframe/en.ts
+++ b/src/global-shared/localization/translations/iframe/en.ts
@@ -1,0 +1,439 @@
+import type { IframeLocalizationKeys } from '../../types/iframe-localization-keys';
+
+export const iframeEn: IframeLocalizationKeys = {
+  links: {
+    newIssue: {
+      title: 'New issue',
+    },
+  },
+
+  validation: {
+    required: 'This field is required.',
+    repoRequiredForSearch: "Search queries must include a 'repo:owner/repo' term.",
+    invalidTarget: 'Must be a valid GitHub repository or project URL.',
+  },
+
+  common: {
+    unselectAll: 'Unselect all',
+    saving: 'Saving…',
+  },
+
+  header: {
+    navigation: {
+      backButton: {
+        tooltipText: 'Go back',
+      },
+      forwardButton: {
+        tooltipText: 'Go forward',
+      },
+      refreshButton: {
+        tooltipText: 'Refresh page',
+      },
+    },
+    menu: {
+      anchorButton: {
+        tooltipText: 'Menu',
+      },
+      items: {
+        documentation: {
+          title: 'Docs',
+        },
+        settings: {
+          title: 'Settings',
+        },
+        signOut: {
+          title: 'Sign Out',
+        },
+      },
+    },
+    signInButton: {
+      title: 'Sign in',
+    },
+  },
+
+  settingsForm: {
+    language: {
+      label: 'Language',
+      values: {
+        en: 'English',
+        ru: 'Русский',
+      },
+    },
+    theme: {
+      label: 'Theme',
+      values: {
+        auto: 'System',
+        dark: 'Dark',
+        light: 'Light',
+      },
+    },
+    widgetTheme: {
+      label: 'Widget Theme',
+      values: {
+        light: 'Light',
+        dark: 'Dark',
+      },
+    },
+    issue: {
+      label: 'Issue content',
+      fields: {
+        includeComments: 'Comments',
+        includeAssignees: 'Assignees',
+        includeLabels: 'Labels',
+        includeProjects: 'Projects',
+        includeMilestone: 'Milestone',
+        includeRelationship: 'Relationship',
+        includeDevelopment: 'Development',
+      },
+    },
+    pullRequest: {
+      label: 'Pull Request content',
+      fields: {
+        includeComments: 'Comments',
+        includeAssignees: 'Assignees',
+        includeLabels: 'Labels',
+        includeProjects: 'Projects',
+        includeMilestone: 'Milestone',
+        includeRelationship: 'Relationship',
+        includeDevelopment: 'Development',
+      },
+    },
+    project: {
+      label: 'Project content',
+      fields: {
+        customField: 'Custom field',
+        customFieldCaption:
+          'Name of the GitHub Project field used to display item status (e.g. "Status").',
+      },
+    },
+    defaultTargetUrl: {
+      label: 'Default target URL',
+      caption: 'Pre-fills the target field when creating a new issue (repository or project URL).',
+      placeholder: 'https://github.com/owner/repo',
+    },
+    submitButton: 'Save Settings',
+  },
+
+  issueImportForm: {
+    searchField: {
+      label: 'Search',
+      placeholder: 'https://github.com/username/repo/issues/1',
+    },
+  },
+
+  issueCreateForm: {
+    targetField: {
+      label: 'Target',
+      caption: 'Where the issue will be created',
+      placeholder: 'Repository or project',
+    },
+    titleField: {
+      label: 'Title',
+      caption: 'Short issue summary',
+      placeholder: 'Enter issue title',
+    },
+    descriptionField: {
+      label: 'Description',
+      caption: 'Detailed issue description',
+      placeholder: 'Enter issue description',
+    },
+  },
+
+  issuePage: {
+    title: 'Issue',
+    actionImport: {
+      label: 'Import',
+    },
+  },
+
+  pullRequestPage: {
+    title: 'Pull request',
+    actionImport: {
+      label: 'Import',
+    },
+  },
+
+  issueCreatePage: {
+    title: 'Create Issue',
+    actionCreate: {
+      label: 'Create',
+    },
+    actionImportIssue: {
+      label: 'Import issue',
+    },
+    actionCancel: {
+      label: 'Cancel',
+    },
+  },
+
+  projectPage: {
+    title: 'Project',
+    footerActions: {
+      import: {
+        title: 'Import',
+      },
+      importWithProject: {
+        title: 'Also import project',
+      },
+    },
+  },
+
+  repoPages: {
+    title: 'Repository',
+    navigation: {
+      issues: 'Issues',
+      pullRequests: 'Pull Requests',
+      projects: 'Projects',
+    },
+  },
+
+  repoIssuesPage: {
+    footerActions: {
+      import: {
+        title: 'Import',
+      },
+    },
+  },
+
+  searchPage: {
+    title: 'Search result',
+  },
+
+  settingsPage: {
+    title: 'Settings',
+  },
+
+  documentationPage: {
+    title: 'Docs',
+    intro: 'Learn how to use the Figma GitHub Integration plugin.',
+    sections: {
+      gettingStarted: {
+        title: 'Getting Started',
+        body: 'Sign in using GitHub OAuth (click "Log in with GitHub") or paste a Personal Access Token manually. The token needs repo and read:user scopes. Once authenticated, you can import issues, pull requests, and projects directly into Figma.',
+      },
+      import: {
+        title: 'Importing Issues & Pull Requests',
+        body: 'Paste a GitHub issue or pull request URL into the search bar on the home screen and press Enter. To import multiple items, open a repository and use checkboxes to select several at once, then click Import.',
+      },
+      projects: {
+        title: 'Importing Projects',
+        body: 'Paste a GitHub Project URL (e.g. https://github.com/orgs/myorg/projects/1) into the search bar. The plugin fetches all items in the project so you can select which ones to place on the canvas.',
+      },
+      createIssue: {
+        title: 'Creating Issues',
+        body: 'Use the "New issue" button on the home screen. Choose a target repository or project, fill in a title and optional description, then click Create. The new issue can be automatically imported to Figma.',
+      },
+      search: {
+        title: 'Search',
+        body: 'The search bar supports GitHub search syntax. Use qualifiers such as: repo:owner/repo, type:issue, type:pr, state:open, state:closed, sort:created, sort:updated. Example: repo:vercel/next.js state:open type:issue',
+      },
+      settings: {
+        title: 'Settings',
+        body: 'Open Settings from the menu (top-right corner). Change the language (English / Russian), choose a theme (System, Light, or Dark), and toggle which fields are included when importing issues and pull requests: comments, assignees, labels, milestone, relationships, and development info.\n\nFor projects, you can set the Custom field — the name of the GitHub Project field used to display item status on the widget (e.g. "Status").',
+      },
+      widget: {
+        title: 'Widget',
+        body: 'Each imported item becomes a widget on the Figma canvas. Widgets show four tabs: Overview (title, status, metadata), Body (description), Comments, and Relatives (linked issues or PRs). Use the Sync button to refresh with the latest data from GitHub.',
+      },
+      keyboardShortcuts: {
+        title: 'Keyboard Shortcuts',
+        body: 'Cmd+← / Ctrl+← — Go back\nCmd+→ / Ctrl+→ — Go forward\n/ — Focus search',
+      },
+    },
+  },
+
+  authorizationPage: {
+    title: 'Authorization',
+    alreadyLoggedIn: 'You are already logged in.',
+    tokenVerifyError: 'Failed to verify token',
+    loginWithGitHub: 'Log in with GitHub',
+    connectingToGitHub: 'Connecting to GitHub...',
+    waitingForAuthorization: 'Waiting for authorization...',
+    cancelAuthorization: 'Cancel',
+    form: {
+      tokenErrorTitle: 'Token Error',
+      addManualToken: 'Add Manual Token',
+      showToken: 'Show',
+      hideToken: 'Hide',
+      generateToken: 'Generate Personal Access Token',
+    },
+  },
+
+  entity: {
+    shared: {
+      entityPreview: {
+        metadataSection: {
+          title: 'Metadata',
+        },
+        comments: {
+          loadMore: 'Load more comments',
+          loading: 'Loading...',
+        },
+      },
+    },
+    issue: {
+      entityPreview: {
+        metadataGroup: {
+          assignees: {
+            title: 'Assignees',
+            emptyText: 'No assignees',
+          },
+          labels: {
+            title: 'Labels',
+            emptyText: 'No labels',
+          },
+          projects: {
+            title: 'Projects',
+            emptyText: 'No projects',
+          },
+          milestone: {
+            title: 'Milestone',
+            emptyText: 'No milestone',
+          },
+          relationship: {
+            title: 'Relationship',
+            emptyText: 'None yet',
+            issueParent: {
+              title: 'Issue Parent',
+            },
+          },
+          development: {
+            title: 'Development',
+            emptyText: 'None yet',
+          },
+        },
+      },
+      table: {
+        title: 'Issues',
+        header: {
+          filters: {
+            opened: {
+              title: 'Opened',
+            },
+            draft: {
+              title: 'Draft',
+            },
+            closed: {
+              title: 'Closed',
+            },
+          },
+        },
+        entityRow: {
+          openedByText: 'opened by',
+          unknownAuthor: 'unknown',
+        },
+        selection: {
+          stats: '{selectedCount} of {totalCount} selected',
+          stats_one: '{selectedCount} of {totalCount} selected',
+          stats_other: '{selectedCount} of {totalCount} selected',
+        },
+        emptyState: {
+          noOpenItems: 'No open issues',
+          noClosedItems: 'No closed issues',
+        },
+      },
+    },
+    pullRequest: {
+      entityPreview: {
+        metadataGroup: {
+          assignees: {
+            title: 'Assignees',
+            emptyText: 'No assignees',
+          },
+          labels: {
+            title: 'Labels',
+            emptyText: 'No labels',
+          },
+          projects: {
+            title: 'Projects',
+            emptyText: 'No projects',
+          },
+          milestone: {
+            title: 'Milestone',
+            emptyText: 'No milestone',
+          },
+        },
+      },
+      table: {
+        title: 'Pull Request',
+        header: {
+          filters: {
+            opened: {
+              title: 'Opened',
+            },
+            closed: {
+              title: 'Closed',
+            },
+          },
+        },
+        entityRow: {
+          openedByText: 'opened by',
+          unknownAuthor: 'unknown',
+        },
+        selection: {
+          stats: '{selectedCount} of {totalCount} selected',
+          stats_one: '{selectedCount} of {totalCount} selected',
+          stats_other: '{selectedCount} of {totalCount} selected',
+        },
+        emptyState: {
+          noOpenItems: 'No open pull requests',
+          noClosedItems: 'No closed pull requests',
+        },
+      },
+    },
+    project: {
+      table: {
+        title: 'Projects',
+        header: {
+          filters: {
+            opened: {
+              title: 'Opened',
+            },
+            closed: {
+              title: 'Closed',
+            },
+          },
+        },
+        entityRow: {
+          updatedText: 'updated',
+        },
+        emptyState: {
+          noOpenItems: 'No open projects',
+          noClosedItems: 'No closed projects',
+        },
+      },
+    },
+  },
+
+  errors: {
+    offline: 'You seem to be offline. Please check your connection.',
+    invalidGithubData: 'Invalid provided GitHub data or missing access token',
+    missingAccessToken: 'GitHub access token is missing',
+    invalidUrl: 'Invalid GitHub URL. Please enter a valid GitHub URL.',
+    unableToProcess:
+      'Unable to process the provided GitHub data. Please check if the item exists and try again.',
+    invalidLink:
+      'Please provide a valid link to a GitHub issue, pull request, project or repository',
+    repositoryMissingData:
+      'Repository data is missing owner or name. Provide a repository URL or owner/name.',
+    noIssuesFound: 'No issues or pull requests were found',
+    notFound: 'Not found',
+    failedToConnect: 'Failed to connect to auth server',
+    invalidAuthUrl: 'Invalid auth URL',
+    authTimeout: 'Authentication timed out. Please try again.',
+    serverUnavailable: 'Server unavailable',
+  },
+
+  uiComponents: {
+    searchField: {
+      tooltipText: 'Search',
+    },
+    htmlBody: {
+      emptyText: 'No description provided',
+    },
+  },
+
+  ui: {
+    accessTokenWithScope: 'Access Token',
+  },
+};

--- a/src/global-shared/localization/translations/iframe/index.ts
+++ b/src/global-shared/localization/translations/iframe/index.ts
@@ -1,0 +1,10 @@
+import type { IframeLocalizationKeys } from '../../types/iframe-localization-keys';
+import type { Locale } from '../../types/locales';
+
+import { iframeEn } from './en';
+import { iframeRu } from './ru';
+
+export const iframeTranslations: Record<Locale, IframeLocalizationKeys> = {
+  en: iframeEn,
+  ru: iframeRu,
+};

--- a/src/global-shared/localization/translations/iframe/ru.ts
+++ b/src/global-shared/localization/translations/iframe/ru.ts
@@ -1,0 +1,444 @@
+import type { IframeLocalizationKeys } from '../../types/iframe-localization-keys';
+
+export const iframeRu: IframeLocalizationKeys = {
+  links: {
+    newIssue: {
+      title: 'Новая задача',
+    },
+  },
+
+  validation: {
+    required: 'Поле обязательно для заполнения',
+    repoRequiredForSearch: "Поисковые запросы должны содержать 'repo:владелец/репозиторий'.",
+    invalidTarget: 'Должен быть действительный URL репозитория или проекта GitHub.',
+  },
+
+  common: {
+    unselectAll: 'Очистить выбор',
+    saving: 'Сохранение...',
+  },
+
+  header: {
+    navigation: {
+      backButton: {
+        tooltipText: 'Назад',
+      },
+      forwardButton: {
+        tooltipText: 'Вперед',
+      },
+      refreshButton: {
+        tooltipText: 'Обновить страницу',
+      },
+    },
+    menu: {
+      anchorButton: {
+        tooltipText: 'Меню',
+      },
+      items: {
+        documentation: {
+          title: 'Документация',
+        },
+        settings: {
+          title: 'Настройки',
+        },
+        signOut: {
+          title: 'Выйти',
+        },
+      },
+    },
+    signInButton: {
+      title: 'Войти',
+    },
+  },
+
+  settingsForm: {
+    language: {
+      label: 'Язык',
+      values: {
+        en: 'Английский',
+        ru: 'Русский',
+      },
+    },
+    theme: {
+      label: 'Тема',
+      values: {
+        auto: 'Системная',
+        dark: 'Тёмная',
+        light: 'Светлая',
+      },
+    },
+    widgetTheme: {
+      label: 'Тема виджета',
+      values: {
+        light: 'Светлая',
+        dark: 'Тёмная',
+      },
+    },
+    issue: {
+      label: 'Содержимое issue',
+      fields: {
+        includeComments: 'Комментарии',
+        includeAssignees: 'Исполнители',
+        includeLabels: 'Метки',
+        includeProjects: 'Проекты',
+        includeMilestone: 'Этап (milestone)',
+        includeRelationship: 'Связи',
+        includeDevelopment: 'Разработка',
+      },
+    },
+    pullRequest: {
+      label: 'Содержимое pull request',
+      fields: {
+        includeComments: 'Комментарии',
+        includeAssignees: 'Исполнители',
+        includeLabels: 'Метки',
+        includeProjects: 'Проекты',
+        includeMilestone: 'Этап (milestone)',
+        includeRelationship: 'Связи',
+        includeDevelopment: 'Разработка',
+      },
+    },
+    project: {
+      label: 'Содержимое проекта',
+      fields: {
+        customField: 'Кастомное поле',
+        customFieldCaption:
+          'Название поля GitHub Project, отображающего статус элемента (например, «Status»).',
+      },
+    },
+    // TODO: Поправить называния
+    defaultTargetUrl: {
+      label: 'URL цели по умолчанию',
+      caption: 'Предзаполняет поле цели при создании новой задачи (URL репозитория или проекта).',
+      placeholder: 'https://github.com/owner/repo',
+    },
+    submitButton: 'Сохранить настройки',
+  },
+
+  issueImportForm: {
+    searchField: {
+      label: 'Поиск',
+      placeholder: 'https://github.com/username/repo/issues/1',
+    },
+  },
+
+  issueCreateForm: {
+    targetField: {
+      label: 'Цель',
+      caption: 'Куда будет создана задача',
+      placeholder: 'Репозиторий или проект',
+    },
+    titleField: {
+      label: 'Заголовок',
+      caption: 'Краткое описание задачи',
+      placeholder: 'Введите заголовок задачи',
+    },
+    descriptionField: {
+      label: 'Описание',
+      caption: 'Подробное описание задачи',
+      placeholder: 'Введите описание задачи',
+    },
+  },
+
+  issuePage: {
+    title: 'Задача',
+    actionImport: {
+      label: 'Импортировать',
+    },
+  },
+
+  pullRequestPage: {
+    title: 'Пул-реквест',
+    actionImport: {
+      label: 'Импортировать',
+    },
+  },
+
+  issueCreatePage: {
+    title: 'Новая задача',
+    actionCreate: {
+      label: 'Создать',
+    },
+    actionImportIssue: {
+      label: 'Импортировать',
+    },
+    actionCancel: {
+      label: 'Отмена',
+    },
+  },
+
+  projectPage: {
+    title: 'Проект',
+    footerActions: {
+      import: {
+        title: 'Импортировать',
+      },
+      importWithProject: {
+        title: 'Также импортировать проект',
+      },
+    },
+  },
+
+  repoPages: {
+    title: 'Репозиторий',
+    navigation: {
+      issues: 'Задачи',
+      pullRequests: 'Пул-реквесты',
+      projects: 'Проекты',
+    },
+  },
+
+  repoIssuesPage: {
+    footerActions: {
+      import: {
+        title: 'Импортировать',
+      },
+    },
+  },
+
+  searchPage: {
+    title: 'Результат поиска',
+  },
+
+  settingsPage: {
+    title: 'Настройки',
+  },
+
+  documentationPage: {
+    title: 'Документация',
+    intro: 'Узнайте, как пользоваться плагином Figma GitHub Integration.',
+    sections: {
+      gettingStarted: {
+        title: 'Начало работы',
+        body: 'Войдите через GitHub OAuth (кнопка «Войти через GitHub») или введите Personal Access Token вручную. Токену необходимы права repo и read:user. После авторизации вы сможете импортировать задачи, pull request-ы и проекты прямо в Figma.',
+      },
+      import: {
+        title: 'Импорт задач и pull request-ов',
+        body: 'Вставьте ссылку на задачу или pull request в строку поиска на главном экране и нажмите Enter. Чтобы импортировать несколько элементов, откройте репозиторий, отметьте нужные чекбоксами и нажмите «Импортировать».',
+      },
+      projects: {
+        title: 'Импорт проектов',
+        body: 'Вставьте ссылку на GitHub Project (например, https://github.com/orgs/myorg/projects/1) в строку поиска. Плагин загрузит все элементы проекта — выберите нужные для размещения на холсте.',
+      },
+      createIssue: {
+        title: 'Создание задачи',
+        body: 'Нажмите кнопку «Новая задача» на главном экране. Выберите репозиторий или проект, введите заголовок и описание (необязательно), затем нажмите «Создать». Созданная задача может быть автоматически импортирована в Figma.',
+      },
+      search: {
+        title: 'Поиск',
+        body: 'Строка поиска поддерживает синтаксис GitHub Search. Используйте фильтры: repo:владелец/репозиторий, type:issue, type:pr, state:open, state:closed, sort:created, sort:updated. Пример: repo:vercel/next.js state:open type:issue',
+      },
+      settings: {
+        title: 'Настройки',
+        body: 'Откройте настройки через меню (правый верхний угол). Можно сменить язык (Русский / Английский), тему (Системная, Светлая, Тёмная) и выбрать, какие поля включать при импорте задач и pull request-ов: комментарии, ответственные, метки, этап, связи и информация о разработке.\n\nДля проектов доступна настройка «Кастомное поле» — название поля GitHub Project, отображающего статус элемента на виджете (например, «Status»).',
+      },
+      widget: {
+        title: 'Виджет',
+        body: 'Каждый импортированный элемент становится виджетом на холсте Figma. Виджет содержит четыре вкладки: Обзор (заголовок, статус, метаданные), Тело (описание), Комментарии и Связанные (связанные задачи или PR). Кнопка «Синхронизировать» обновляет данные из GitHub.',
+      },
+      keyboardShortcuts: {
+        title: 'Горячие клавиши',
+        body: 'Cmd+← / Ctrl+← — Назад\nCmd+→ / Ctrl+→ — Вперёд\n/ — Фокус поиска',
+      },
+    },
+  },
+
+  authorizationPage: {
+    title: 'Авторизация',
+    alreadyLoggedIn: 'Вы уже вошли в систему.',
+    tokenVerifyError: 'Не удалось проверить токен',
+    loginWithGitHub: 'Войти через GitHub',
+    connectingToGitHub: 'Подключение к GitHub...',
+    waitingForAuthorization: 'Ожидание авторизации...',
+    cancelAuthorization: 'Отмена',
+    form: {
+      tokenErrorTitle: 'Ошибка токена',
+      addManualToken: 'Добавить токен вручную',
+      showToken: 'Показать',
+      hideToken: 'Скрыть',
+      generateToken: 'Создать персональный токен доступа',
+    },
+  },
+
+  entity: {
+    shared: {
+      entityPreview: {
+        metadataSection: {
+          title: 'Метаданные',
+        },
+        comments: {
+          loadMore: 'Загрузить ещё комментарии',
+          loading: 'Загрузка...',
+        },
+      },
+    },
+    issue: {
+      entityPreview: {
+        metadataGroup: {
+          assignees: {
+            title: 'Ответственные',
+            emptyText: 'Нет ответственных',
+          },
+          labels: {
+            title: 'Метки',
+            emptyText: 'Нет меток',
+          },
+          projects: {
+            title: 'Проекты',
+            emptyText: 'Нет проектов',
+          },
+          milestone: {
+            title: 'Этап (milestone)',
+            emptyText: 'Нет этапа',
+          },
+          relationship: {
+            title: 'Связи',
+            emptyText: 'Пока нет',
+            issueParent: {
+              title: 'Родительская задача',
+            },
+          },
+          development: {
+            title: 'Разработка',
+            emptyText: 'Пока нет',
+          },
+        },
+      },
+      table: {
+        title: 'Задачи',
+        header: {
+          filters: {
+            opened: {
+              title: 'Открытые',
+            },
+            draft: {
+              title: 'Черновые',
+            },
+            closed: {
+              title: 'Закрытые',
+            },
+          },
+        },
+        entityRow: {
+          openedByText: 'открыта',
+          unknownAuthor: 'неизвестно',
+        },
+        selection: {
+          stats: 'Выбрано {selectedCount} из {totalCount}',
+          stats_one: 'Выбран {selectedCount} из {totalCount}',
+          stats_few: 'Выбрано {selectedCount} из {totalCount}',
+          stats_many: 'Выбрано {selectedCount} из {totalCount}',
+          stats_other: 'Выбрано {selectedCount} из {totalCount}',
+        },
+        emptyState: {
+          noOpenItems: 'Нет открытых задач',
+          noClosedItems: 'Нет закрытых задач',
+        },
+      },
+    },
+    pullRequest: {
+      entityPreview: {
+        metadataGroup: {
+          assignees: {
+            title: 'Ответственные',
+            emptyText: 'Нет ответственных',
+          },
+          labels: {
+            title: 'Метки',
+            emptyText: 'Нет меток',
+          },
+          projects: {
+            title: 'Проекты',
+            emptyText: 'Нет проектов',
+          },
+          milestone: {
+            title: 'Этап (milestone)',
+            emptyText: 'Нет этапа',
+          },
+        },
+      },
+      table: {
+        title: 'Пул-реквесты',
+        header: {
+          filters: {
+            opened: {
+              title: 'Открытые',
+            },
+            closed: {
+              title: 'Закрытые',
+            },
+          },
+        },
+        entityRow: {
+          openedByText: 'открыта',
+          unknownAuthor: 'неизвестно',
+        },
+        selection: {
+          stats: 'Выбрано {selectedCount} из {totalCount}',
+          stats_one: 'Выбран {selectedCount} из {totalCount}',
+          stats_few: 'Выбрано {selectedCount} из {totalCount}',
+          stats_many: 'Выбрано {selectedCount} из {totalCount}',
+          stats_other: 'Выбрано {selectedCount} из {totalCount}',
+        },
+        emptyState: {
+          noOpenItems: 'Нет открытых пул-реквестов',
+          noClosedItems: 'Нет закрытых пул-реквестов',
+        },
+      },
+    },
+    project: {
+      table: {
+        title: 'Проекты',
+        header: {
+          filters: {
+            opened: {
+              title: 'Открытые',
+            },
+            closed: {
+              title: 'Закрытые',
+            },
+          },
+        },
+        entityRow: {
+          updatedText: 'обновлено',
+        },
+        emptyState: {
+          noOpenItems: 'Нет открытых проектов',
+          noClosedItems: 'Нет закрытых проектов',
+        },
+      },
+    },
+  },
+
+  errors: {
+    offline: 'Похоже, вы не в сети. Пожалуйста, проверьте подключение к интернету.',
+    invalidGithubData: 'Неверные данные GitHub или отсутствует токен доступа',
+    missingAccessToken: 'Отсутствует токен доступа GitHub',
+    invalidUrl: 'Неверный URL GitHub. Пожалуйста, введите корректный URL GitHub.',
+    unableToProcess:
+      'Не удается обработать предоставленные данные GitHub. Пожалуйста, проверьте, существует ли элемент, и повторите попытку.',
+    invalidLink:
+      'Пожалуйста, предоставьте корректную ссылку на задачу, pull request, проект или репозиторий GitHub',
+    repositoryMissingData:
+      'В данных репозитория отсутствует владелец или имя. Укажите URL репозитория или владелец/имя.',
+    noIssuesFound: 'Задачи или pull request-ы не найдены',
+    notFound: 'Не найдено',
+    failedToConnect: 'Не удалось подключиться к серверу авторизации',
+    invalidAuthUrl: 'Неверный URL авторизации',
+    authTimeout: 'Время авторизации истекло. Попробуйте снова.',
+    serverUnavailable: 'Сервер не доступен',
+  },
+
+  uiComponents: {
+    searchField: {
+      tooltipText: 'Найти',
+    },
+    htmlBody: {
+      emptyText: 'Нет описания',
+    },
+  },
+
+  ui: {
+    accessTokenWithScope: 'Токен доступа',
+  },
+};

--- a/src/global-shared/localization/translations/index.ts
+++ b/src/global-shared/localization/translations/index.ts
@@ -1,0 +1,2 @@
+export { widgetTranslations } from './widget';
+export { iframeTranslations } from './iframe';

--- a/src/global-shared/localization/translations/widget/en.ts
+++ b/src/global-shared/localization/translations/widget/en.ts
@@ -1,0 +1,61 @@
+import type { WidgetLocalizationKeys } from '../../types/widget-localization-keys';
+
+export const widgetEn: WidgetLocalizationKeys = {
+  common: {
+    description: 'Description',
+    import: 'Import',
+  },
+
+  ui: {
+    lastSynced: 'Last synced',
+    syncAction: 'Sync',
+    updatedAt: 'Updated At',
+    projects: 'Projects',
+  },
+
+  widget: {
+    importIssue: 'Import Issue/PR/Project',
+    createIssue: 'Create Issue',
+    moreComments: 'More Comments',
+    loadMoreComments: 'Load more comments',
+    taskProgress: 'Task progress',
+    completedIssues: 'Completed Issues',
+  },
+
+  tabs: {
+    overview: 'Overview',
+    body: 'Body',
+    comments: 'Comments',
+    relatives: 'Relatives',
+  },
+
+  entityMetadata: {
+    assignee: { fieldTitle: 'Assignee' },
+    labels: { fieldTitle: 'Labels', emptyText: 'No labels' },
+    projectField: { fieldTitle: 'Project field: {title}', emptyText: 'No project field' },
+    relatives: { fieldTitle: 'Relationship' },
+    projects: { fieldTitle: 'Projects', emptyText: 'No projects' },
+    milestone: { fieldTitle: 'Milestone', emptyText: 'No milestone' },
+    development: { fieldTitle: 'Development', emptyText: 'No linked items' },
+    importedEntities: { fieldTitle: 'Imported entities', emptyText: 'No entities' },
+    notImportedEntities: { fieldTitle: 'Not imported', emptyText: 'All imported' },
+  },
+
+  success: {
+    tokenRemoved: 'Successfully Removed Github API Token!',
+    tokenAuthorized: 'Successfully authorized Github API Token!',
+    tokenAuthorizedOAuth: 'Successfully signed in via GitHub OAuth!',
+    settingsSaved: 'Successfully save new settings!',
+    issueResynced: 'Issue {title} resynced!',
+    pullRequestResynced: 'Pull request {title} resynced!',
+    issuesImported: 'Successfully imported {count} issues!',
+    issueImported: 'Successfully imported {title} issue!',
+    pullRequestImported: 'Successfully imported {title} pull request!',
+    projectImported: 'Successfully imported {title} project!',
+  },
+
+  notifications: {
+    unableToResync: 'Unable to resync at this time, please try again.',
+    errorImportingIssues: 'Error importing issues from repository',
+  },
+};

--- a/src/global-shared/localization/translations/widget/index.ts
+++ b/src/global-shared/localization/translations/widget/index.ts
@@ -1,0 +1,10 @@
+import type { Locale } from '../../types/locales';
+import type { WidgetLocalizationKeys } from '../../types/widget-localization-keys';
+
+import { widgetEn } from './en';
+import { widgetRu } from './ru';
+
+export const widgetTranslations: Record<Locale, WidgetLocalizationKeys> = {
+  en: widgetEn,
+  ru: widgetRu,
+};

--- a/src/global-shared/localization/translations/widget/ru.ts
+++ b/src/global-shared/localization/translations/widget/ru.ts
@@ -1,0 +1,61 @@
+import type { WidgetLocalizationKeys } from '../../types/widget-localization-keys';
+
+export const widgetRu: WidgetLocalizationKeys = {
+  common: {
+    description: 'Описание',
+    import: 'Импорт',
+  },
+
+  ui: {
+    lastSynced: 'Последняя синхронизация',
+    syncAction: 'Обновить',
+    updatedAt: 'Обновлено',
+    projects: 'Проекты',
+  },
+
+  widget: {
+    importIssue: 'Импорт задачи/PR/проекта',
+    createIssue: 'Создать задачу',
+    moreComments: 'Больше комментариев',
+    loadMoreComments: 'Загрузить ещё комментарии',
+    taskProgress: 'Прогресс задач',
+    completedIssues: 'Завершенные задачи',
+  },
+
+  tabs: {
+    overview: 'Обзор',
+    body: 'Описание',
+    comments: 'Комментарии',
+    relatives: 'Связанное',
+  },
+
+  entityMetadata: {
+    assignee: { fieldTitle: 'Исполнители' },
+    labels: { fieldTitle: 'Метки', emptyText: 'Нет меток' },
+    projectField: { fieldTitle: 'Поле проекта: {title}', emptyText: 'Нет поля проекта' },
+    relatives: { fieldTitle: 'Связи' },
+    projects: { fieldTitle: 'Проекты', emptyText: 'Нет проектов' },
+    milestone: { fieldTitle: 'Этап (milestone)', emptyText: 'Нет этапа' },
+    development: { fieldTitle: 'Разработка', emptyText: 'Нет связанных объектов' },
+    importedEntities: { fieldTitle: 'Импортированные сущности', emptyText: 'Нет объектов' },
+    notImportedEntities: { fieldTitle: 'Не импортировано', emptyText: 'Все импортированы' },
+  },
+
+  success: {
+    tokenRemoved: 'Токен GitHub API успешно удален!',
+    tokenAuthorized: 'Токен GitHub API успешно авторизован!',
+    tokenAuthorizedOAuth: 'Успешный вход через GitHub OAuth!',
+    settingsSaved: 'Новые настройки успешно сохранены!',
+    issueResynced: 'Задача {title} синхронизирована!',
+    pullRequestResynced: 'Пул-реквест {title} синхронизирован!',
+    issuesImported: 'Успешно импортировано {count} задач!',
+    issueImported: 'Задача {title} успешно импортирована!',
+    pullRequestImported: 'Пул-реквест {title} успешно импортирован!',
+    projectImported: 'Проект {title} успешно импортирован!',
+  },
+
+  notifications: {
+    unableToResync: 'Не удается выполнить синхронизацию в данный момент, попробуйте еще раз.',
+    errorImportingIssues: 'Ошибка при импорте задач из репозитория',
+  },
+};

--- a/src/global-shared/localization/types/iframe-localization-keys.ts
+++ b/src/global-shared/localization/types/iframe-localization-keys.ts
@@ -1,0 +1,427 @@
+export type IframeLocalizationKeys = {
+  links: {
+    newIssue: {
+      title: string;
+    };
+  };
+
+  validation: {
+    required: string;
+    repoRequiredForSearch: string;
+    invalidTarget: string;
+  };
+
+  common: {
+    unselectAll: string;
+    saving: string;
+  };
+
+  header: {
+    navigation: {
+      backButton: {
+        tooltipText: string;
+      };
+      forwardButton: {
+        tooltipText: string;
+      };
+      refreshButton: {
+        tooltipText: string;
+      };
+    };
+    menu: {
+      anchorButton: {
+        tooltipText: string;
+      };
+      items: {
+        documentation: {
+          title: string;
+        };
+        settings: {
+          title: string;
+        };
+        signOut: {
+          title: string;
+        };
+      };
+    };
+    signInButton: {
+      title: string;
+    };
+  };
+
+  settingsForm: {
+    language: {
+      label: string;
+      values: {
+        en: string;
+        ru: string;
+      };
+    };
+    theme: {
+      label: string;
+      values: {
+        auto: string;
+        light: string;
+        dark: string;
+      };
+    };
+    widgetTheme: {
+      label: string;
+      values: {
+        light: string;
+        dark: string;
+      };
+    };
+    issue: {
+      label: string;
+      fields: {
+        includeComments: string;
+        includeAssignees: string;
+        includeLabels: string;
+        includeProjects: string;
+        includeMilestone: string;
+        includeRelationship: string;
+        includeDevelopment: string;
+      };
+    };
+    pullRequest: {
+      label: string;
+      fields: {
+        includeComments: string;
+        includeAssignees: string;
+        includeLabels: string;
+        includeProjects: string;
+        includeMilestone: string;
+        includeRelationship: string;
+        includeDevelopment: string;
+      };
+    };
+    project: {
+      label: string;
+      fields: {
+        customField: string;
+        customFieldCaption: string;
+      };
+    };
+    defaultTargetUrl: {
+      label: string;
+      caption: string;
+      placeholder: string;
+    };
+    submitButton: string;
+  };
+
+  issueImportForm: {
+    searchField: {
+      label: string;
+      placeholder: string;
+    };
+  };
+
+  issueCreateForm: {
+    targetField: {
+      label: string;
+      caption: string;
+      placeholder: string;
+    };
+    titleField: {
+      label: string;
+      caption: string;
+      placeholder: string;
+    };
+    descriptionField: {
+      label: string;
+      caption: string;
+      placeholder: string;
+    };
+  };
+
+  issuePage: {
+    title: string;
+    actionImport: {
+      label: string;
+    };
+  };
+
+  pullRequestPage: {
+    title: string;
+    actionImport: {
+      label: string;
+    };
+  };
+
+  issueCreatePage: {
+    title: string;
+    actionCreate: {
+      label: string;
+    };
+    actionImportIssue: {
+      label: string;
+    };
+    actionCancel: {
+      label: string;
+    };
+  };
+
+  projectPage: {
+    title: string;
+    footerActions: {
+      import: {
+        title: string;
+      };
+      importWithProject: {
+        title: string;
+      };
+    };
+  };
+
+  repoPages: {
+    title: string;
+    navigation: {
+      issues: string;
+      pullRequests: string;
+      projects: string;
+    };
+  };
+
+  repoIssuesPage: {
+    footerActions: {
+      import: {
+        title: string;
+      };
+    };
+  };
+
+  searchPage: {
+    title: string;
+  };
+
+  settingsPage: {
+    title: string;
+  };
+
+  documentationPage: {
+    title: string;
+    intro: string;
+    sections: {
+      gettingStarted: { title: string; body: string };
+      import: { title: string; body: string };
+      projects: { title: string; body: string };
+      createIssue: { title: string; body: string };
+      search: { title: string; body: string };
+      settings: { title: string; body: string };
+      widget: { title: string; body: string };
+      keyboardShortcuts: { title: string; body: string };
+    };
+  };
+
+  authorizationPage: {
+    title: string;
+    alreadyLoggedIn: string;
+    tokenVerifyError: string;
+    loginWithGitHub: string;
+    connectingToGitHub: string;
+    waitingForAuthorization: string;
+    cancelAuthorization: string;
+    form: {
+      tokenErrorTitle: string;
+      addManualToken: string;
+      showToken: string;
+      hideToken: string;
+      generateToken: string;
+    };
+  };
+
+  entity: {
+    shared: {
+      entityPreview: {
+        metadataSection: {
+          title: string;
+        };
+        comments: {
+          loadMore: string;
+          loading: string;
+        };
+      };
+    };
+    issue: {
+      entityPreview: {
+        metadataGroup: {
+          assignees: {
+            title: string;
+            emptyText: string;
+          };
+          labels: {
+            title: string;
+            emptyText: string;
+          };
+          projects: {
+            title: string;
+            emptyText: string;
+          };
+          milestone: {
+            title: string;
+            emptyText: string;
+          };
+          relationship: {
+            title: string;
+            emptyText: string;
+            issueParent: {
+              title: string;
+            };
+          };
+          development: {
+            title: string;
+            emptyText: string;
+          };
+        };
+      };
+      table: {
+        title: string;
+        header: {
+          filters: {
+            opened: {
+              title: string;
+            };
+            draft: {
+              title: string;
+            };
+            closed: {
+              title: string;
+            };
+          };
+        };
+        entityRow: {
+          openedByText: string;
+          unknownAuthor: string;
+        };
+        selection: {
+          stats: string;
+          stats_one?: string;
+          stats_few?: string;
+          stats_many?: string;
+          stats_other?: string;
+        };
+        emptyState: {
+          noOpenItems: string;
+          noClosedItems: string;
+        };
+      };
+    };
+    pullRequest: {
+      entityPreview: {
+        metadataGroup: {
+          assignees: {
+            title: string;
+            emptyText: string;
+          };
+          labels: {
+            title: string;
+            emptyText: string;
+          };
+          projects: {
+            title: string;
+            emptyText: string;
+          };
+          milestone: {
+            title: string;
+            emptyText: string;
+          };
+        };
+      };
+      table: {
+        title: string;
+        header: {
+          filters: {
+            opened: {
+              title: string;
+            };
+            closed: {
+              title: string;
+            };
+          };
+        };
+        entityRow: {
+          openedByText: string;
+          unknownAuthor: string;
+        };
+        selection: {
+          stats: string;
+          stats_one?: string;
+          stats_few?: string;
+          stats_many?: string;
+          stats_other?: string;
+        };
+        emptyState: {
+          noOpenItems: string;
+          noClosedItems: string;
+        };
+      };
+    };
+    project: {
+      table: {
+        title: string;
+        header: {
+          filters: {
+            opened: {
+              title: string;
+            };
+            closed: {
+              title: string;
+            };
+          };
+        };
+        entityRow: {
+          updatedText: string;
+        };
+        emptyState: {
+          noOpenItems: string;
+          noClosedItems: string;
+        };
+      };
+    };
+  };
+
+  errors: {
+    offline: string;
+    invalidGithubData: string;
+    missingAccessToken: string;
+    invalidUrl: string;
+    unableToProcess: string;
+    invalidLink: string;
+    repositoryMissingData: string;
+    noIssuesFound: string;
+    notFound: string;
+    failedToConnect: string;
+    invalidAuthUrl: string;
+    authTimeout: string;
+    serverUnavailable: string;
+  };
+
+  uiComponents: {
+    searchField: {
+      tooltipText: string;
+    };
+    htmlBody: {
+      emptyText: string;
+    };
+  };
+
+  ui: {
+    accessTokenWithScope: string;
+  };
+};
+
+type Paths<T> = T extends object
+  ? {
+      [K in keyof T]: K extends string
+        ? T[K] extends string
+          ? K
+          : T[K] extends object
+            ? `${K}.${Paths<T[K]>}`
+            : never
+        : never;
+    }[keyof T]
+  : never;
+
+export type IframeTranslationKey = Paths<IframeLocalizationKeys>;

--- a/src/global-shared/localization/types/index.ts
+++ b/src/global-shared/localization/types/index.ts
@@ -1,0 +1,3 @@
+export type { Locale } from './locales';
+export type { IframeLocalizationKeys, IframeTranslationKey } from './iframe-localization-keys';
+export type { WidgetLocalizationKeys, WidgetTranslationKey } from './widget-localization-keys';

--- a/src/global-shared/localization/types/locales.ts
+++ b/src/global-shared/localization/types/locales.ts
@@ -1,0 +1,1 @@
+export type Locale = 'en' | 'ru';

--- a/src/global-shared/localization/types/widget-localization-keys.ts
+++ b/src/global-shared/localization/types/widget-localization-keys.ts
@@ -1,0 +1,73 @@
+export type WidgetLocalizationKeys = {
+  common: {
+    description: string;
+    import: string;
+  };
+
+  ui: {
+    lastSynced: string;
+    syncAction: string;
+    updatedAt: string;
+    projects: string;
+  };
+
+  widget: {
+    importIssue: string;
+    createIssue: string;
+    moreComments: string;
+    loadMoreComments: string;
+    taskProgress: string;
+    completedIssues: string;
+  };
+
+  tabs: {
+    overview: string;
+    body: string;
+    comments: string;
+    relatives: string;
+  };
+
+  entityMetadata: {
+    assignee: { fieldTitle: string };
+    labels: { fieldTitle: string; emptyText: string };
+    projectField: { fieldTitle: string; emptyText: string };
+    projects: { fieldTitle: string; emptyText: string };
+    relatives: { fieldTitle: string };
+    milestone: { fieldTitle: string; emptyText: string };
+    development: { fieldTitle: string; emptyText: string };
+    importedEntities: { fieldTitle: string; emptyText: string };
+    notImportedEntities: { fieldTitle: string; emptyText: string };
+  };
+
+  success: {
+    tokenRemoved: string;
+    tokenAuthorized: string;
+    tokenAuthorizedOAuth: string;
+    settingsSaved: string;
+    issueResynced: string;
+    pullRequestResynced: string;
+    issuesImported: string;
+    issueImported: string;
+    pullRequestImported: string;
+    projectImported: string;
+  };
+
+  notifications: {
+    unableToResync: string;
+    errorImportingIssues: string;
+  };
+};
+
+type Paths<T> = T extends object
+  ? {
+      [K in keyof T]: K extends string
+        ? T[K] extends string
+          ? K
+          : T[K] extends object
+            ? `${K}.${Paths<T[K]>}`
+            : never
+        : never;
+    }[keyof T]
+  : never;
+
+export type WidgetTranslationKey = Paths<WidgetLocalizationKeys>;

--- a/src/global-shared/localization/utils.ts
+++ b/src/global-shared/localization/utils.ts
@@ -1,0 +1,86 @@
+import type { Locale } from './types';
+
+export function getDefaultLocale(): Locale {
+  const supportedLanguages = {
+    ru: ['ru', 'ru-ru', 'ru-by', 'ru-kz', 'ru-kg', 'ru-md', 'ru-ua'],
+    en: ['en', 'en-us', 'en-gb', 'en-ca', 'en-au', 'en-nz', 'en-za'],
+  };
+
+  const detectLanguage = (locale: string): Locale => {
+    const normalizedLocale = locale.toLowerCase().trim();
+
+    for (const [lang, variants] of Object.entries(supportedLanguages)) {
+      if (variants.includes(normalizedLocale)) {
+        return lang as Locale;
+      }
+    }
+
+    const langCode = normalizedLocale.substring(0, 2);
+    for (const [lang, variants] of Object.entries(supportedLanguages)) {
+      if (variants.some((variant) => variant.startsWith(langCode))) {
+        return lang as Locale;
+      }
+    }
+
+    return 'en';
+  };
+
+  if (typeof figma !== 'undefined' && (figma as any).locale) {
+    try {
+      const detectedLanguage = detectLanguage((figma as any).locale as string);
+
+      return detectedLanguage;
+    } catch (error) {
+      console.warn('Failed to get Figma locale:', error);
+    }
+  }
+
+  return 'en';
+}
+
+export function getNestedValueWithFallback(
+  translations: Record<string, any>,
+  locale: Locale,
+  path: string
+): string {
+  let result = getNestedValue(translations[locale], path);
+
+  if (result === path && locale !== 'en') {
+    result = getNestedValue(translations['en'], path);
+  }
+
+  return result;
+}
+
+export function getNestedValue(obj: any, path: string): string {
+  const keys = path.split('.');
+  let result = obj;
+
+  for (const key of keys) {
+    if (result && typeof result === 'object' && key in result) {
+      result = result[key];
+    } else {
+      return path;
+    }
+  }
+
+  return typeof result === 'string' ? result : path;
+}
+
+export function interpolate(template: string, values: Record<string, string | number>): string {
+  return template.replace(/{(\w+)}/g, (match, key) => {
+    return values[key]?.toString() ?? match;
+  });
+}
+
+export function isValidLocale(locale: string): locale is Locale {
+  return locale === 'en' || locale === 'ru';
+}
+
+export function getSafeLocale(locale: string): Locale {
+  return isValidLocale(locale) ? locale : 'en';
+}
+
+export function getValidLocale(locale: string): Locale {
+  return isValidLocale(locale) ? locale : 'en';
+}

--- a/src/iframe/shared/lib/contexts/internationalization-context.tsx
+++ b/src/iframe/shared/lib/contexts/internationalization-context.tsx
@@ -1,0 +1,104 @@
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
+
+import { createContext, useContext, useState } from 'react';
+
+import {
+  getDefaultLocale,
+  getNestedValueWithFallback,
+  getPluralSuffix,
+  getValidLocale,
+  type IframeTranslationKey,
+  iframeTranslations,
+  interpolate,
+  type Locale,
+} from '../../../../global-shared/localization';
+import { MESSAGE_TYPES } from '../../../../global-shared/message-type';
+import { sendMessageToWidget } from '../utils/send-message-to-widget';
+
+export type InternationalizationContextProps = {
+  locale: Locale;
+  sendLocale: (locale: Locale) => void;
+  setLocale: Dispatch<SetStateAction<Locale>>;
+  t: (key: IframeTranslationKey, values?: Record<string, string | number>) => string;
+};
+
+export const InternationalizationContext = createContext<
+  InternationalizationContextProps | undefined
+>(undefined);
+
+export type InternationalizationProviderProps = {
+  children: ReactNode;
+};
+
+export const InternationalizationProvider = ({ children }: InternationalizationProviderProps) => {
+  const [locale, setLocale] = useState<Locale>(getDefaultLocale());
+
+  const sendLocale = async (newLocale: Locale) => {
+    const validatedLocale = getValidLocale(newLocale);
+    setLocale(validatedLocale);
+
+    sendMessageToWidget({ type: MESSAGE_TYPES.SET_LOCALE, data: { locale: validatedLocale } });
+  };
+
+  const t = (key: IframeTranslationKey, values?: Record<string, string | number>): string => {
+    let translation = '';
+
+    const countVal = values?.count ?? values?.selectedCount;
+
+    if (typeof countVal === 'number') {
+      const suffix = getPluralSuffix(locale, countVal);
+
+      const pluralKey = `${key}_${suffix}`;
+      const pluralTranslation = getNestedValueWithFallback(
+        iframeTranslations,
+        locale,
+        pluralKey as any
+      );
+
+      if (pluralTranslation && pluralTranslation !== pluralKey) {
+        translation = pluralTranslation;
+      } else {
+        const otherKey = `${key}_other`;
+        const otherTranslation = getNestedValueWithFallback(
+          iframeTranslations,
+          locale,
+          otherKey as any
+        );
+        translation = otherTranslation !== otherKey ? otherTranslation : '';
+      }
+    }
+
+    if (!translation) {
+      translation = getNestedValueWithFallback(iframeTranslations, locale, key);
+    }
+
+    if (values) {
+      return interpolate(translation, values);
+    }
+
+    return translation;
+  };
+
+  const contextValue: InternationalizationContextProps = {
+    locale,
+    sendLocale,
+    setLocale,
+    t,
+  };
+
+  return (
+    <InternationalizationContext.Provider value={contextValue}>
+      {children}
+    </InternationalizationContext.Provider>
+  );
+};
+
+export const useTranslation = (): InternationalizationContextProps => {
+  const context = useContext(InternationalizationContext);
+
+  if (!context) {
+    throw new Error('useLocalization must be used within a LocalizationProvider');
+  }
+
+  return context;
+};


### PR DESCRIPTION
## Summary
- Add `src/global-shared/localization/` with full translation infrastructure
- Add English (`en.ts`) and Russian (`ru.ts`) translations for both widget and iframe
- Add locale types (`locales.ts`), localization key types (`widget-localization-keys.ts`, `iframe-localization-keys.ts`)
- Add pluralization utilities (`pluralization.ts`) and translation helpers (`utils.ts`)
- Add `InternationalizationContext` for React-based locale access in iframe

## Test plan
- [ ] Switch language in widget and verify Russian translations appear
- [ ] Verify iframe uses correct locale from context
- [ ] Run `npm run lint:tsc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)